### PR TITLE
Fix bug preventing native SDK from being called after reinitialization

### DIFF
--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -421,7 +421,7 @@ export const NATIVE: SentryNativeWrapper = {
    * Closes the Native Layer SDK
    */
   async closeNativeSdk(): Promise<void> {
-    if (!this.enableNative) {
+    if (!this.nativeIsReady) {
       return;
     }
     if (!this._isModuleLoaded(RNSentry)) {
@@ -429,7 +429,7 @@ export const NATIVE: SentryNativeWrapper = {
     }
 
     return RNSentry.closeNativeSdk().then(() => {
-      this.enableNative = false;
+      this.nativeIsReady = false;
     });
   },
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This commit addresses a bug in the Sentry React Native integration that occurs when calling `Sentry.init({ enableNative: true })`, followed by `Sentry.close()`, and then re-calling `Sentry.init({ enableNative: true })`. The bug prevents the native SDK from being invoked after the reinitialization.

The issue resides in the `closeNativeSdk()` method, where the `enableNative` flag is incorrectly used to determine whether the native SDK should be closed. This flag is not being updated correctly after reinitialization, causing the SDK to remain disabled.

With this change, the `nativeIsReady` flag is used to determine whether the native SDK should be closed, ensuring that subsequent reinitialization correctly enables the native SDK functionality.

This fix ensures that the native SDK will be called as expected after reinitializing with enableNative: true, resolving the issue where the SDK was not invoked due to the bug in the `closeNativeSdk()` method.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?

In my App.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
